### PR TITLE
Use ActiveRecord::Base .with_connection rather than .connection

### DIFF
--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -120,7 +120,9 @@ module ActiveAdmin
     end
 
     def resource_quoted_column_name(column)
-      resource_class.connection.quote_column_name(column)
+      resource_class.with_connection do |connection|
+        connection.quote_column_name(column)
+      end
     end
 
     # Clears all the member actions this resource knows about


### PR DESCRIPTION
Per comment [here][1], calling `ActiveRecord::Base.connection` is soft-deprecated, so this change uses `with_connection`, instead.

[1]: https://github.com/rails/rails/blob/v7.2.1/activerecord/lib/active_record/connection_handling.rb#L259